### PR TITLE
Fixed Typo in function name

### DIFF
--- a/JsonApiApp/JsonApiApp/MainTableViewController.swift
+++ b/JsonApiApp/JsonApiApp/MainTableViewController.swift
@@ -17,7 +17,7 @@ class MainTableViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        getLatesData() // metodu çağır.
+        getLatestData() // metodu çağır.
         
     }
     
@@ -50,7 +50,7 @@ class MainTableViewController: UITableViewController {
     
     
     //MARK: - Functions // JSON ile veriyi aldık. İşledik. Gösterdik.
-    func getLatesData(){
+    func getLatestData(){
         
         Alamofire.request("https://www.doviz.com/api/v1/currencies/all/latest", method: .get).validate().responseJSON { response in
             switch response.result { // sonuc basarılı ise


### PR DESCRIPTION
The function name had a typo in it and fix was done to make it more readable.l